### PR TITLE
solución baltasar sanchez

### DIFF
--- a/apps/lines/admin.py
+++ b/apps/lines/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
-# Register your models here.
+from . import models
+
+admin.site.register(models.LineModel)
+admin.site.register(models.RouteModel)

--- a/apps/lines/factories.py
+++ b/apps/lines/factories.py
@@ -10,7 +10,7 @@ class LineFactory(factory.django.DjangoModelFactory):
         model = models.LineModel
 
     name = factory.Faker('street_name')
-    color = factory.Faker('color_name')
+    color = factory.Faker('hex_color')
 
 
 class RouteFactory(factory.django.DjangoModelFactory):

--- a/apps/lines/factories.py
+++ b/apps/lines/factories.py
@@ -1,0 +1,36 @@
+# coding: utf8
+import factory
+
+from apps.stations.factories import StationFactory
+from . import models
+
+
+class LineFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.LineModel
+
+    name = factory.Faker('street_name')
+    color = factory.Faker('color_name')
+
+
+class RouteFactory(factory.django.DjangoModelFactory):
+    """RouteFactory(stations__num: int = 1)
+
+    Routes factory for testing, will have `stations__num` factory-made Stations associated with this route
+    """
+    class Meta:
+        model = models.RouteModel
+
+    line = factory.SubFactory(LineFactory)
+    direction = factory.Faker('boolean')
+    is_active = factory.Faker('boolean')
+
+    @factory.post_generation
+    def stations(self, create, **kwargs):
+        if not create:
+            return
+        else:
+            num_stations = kwargs.get('num', 1)
+            for _ in range(num_stations):
+                sta = StationFactory()
+                self.stations.add(sta)

--- a/apps/lines/factories.py
+++ b/apps/lines/factories.py
@@ -26,7 +26,7 @@ class RouteFactory(factory.django.DjangoModelFactory):
     is_active = factory.Faker('boolean')
 
     @factory.post_generation
-    def stations(self, create, **kwargs):
+    def stations(self, create, unused, **kwargs):
         if not create:
             return
         else:

--- a/apps/lines/models.py
+++ b/apps/lines/models.py
@@ -13,6 +13,9 @@ class LineModel(models.Model):
     name = models.CharField(max_length=100)
     color = models.CharField(max_length=8)
 
+    def __str__(self):
+        return self.name
+
 
 class RouteModel(models.Model):
 
@@ -22,3 +25,6 @@ class RouteModel(models.Model):
     stations = models.ManyToManyField(StationModel)
     direction = models.BooleanField(default=True)
     is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return f'Route for {self.line_id}'

--- a/apps/lines/models.py
+++ b/apps/lines/models.py
@@ -7,6 +7,8 @@ from apps.utils import create_id
 
 
 class LineModel(models.Model):
+    class Meta:
+        ordering = ('id',)
 
     id = models.CharField(default=create_id('line_'), primary_key=True,
                           max_length=30, unique=True)
@@ -18,6 +20,8 @@ class LineModel(models.Model):
 
 
 class RouteModel(models.Model):
+    class Meta:
+        ordering = ('id',)
 
     id = models.CharField(default=create_id('route_'), primary_key=True,
                           max_length=30, unique=True)

--- a/apps/lines/serializers.py
+++ b/apps/lines/serializers.py
@@ -1,0 +1,16 @@
+# coding: utf8
+from rest_framework.serializers import HyperlinkedModelSerializer
+
+from . import models
+
+
+class LineSerializer(HyperlinkedModelSerializer):
+    class Meta:
+        model = models.LineModel
+        exclude = []
+
+
+class RouteSerializer(HyperlinkedModelSerializer):
+    class Meta:
+        model = models.RouteModel
+        exclude = []

--- a/apps/lines/tests.py
+++ b/apps/lines/tests.py
@@ -1,2 +1,53 @@
 # coding: utf8
-from django.test import TestCase
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from users.factories import UserFactory
+from . import factories
+
+
+class LineCRUDTest(APITestCase):
+    url = reverse('linemodel-list')
+
+    def setUp(self):
+        self.client.force_login(UserFactory())
+
+    def test_list_create(self):
+        response = self.client.get(self.url)
+        response = response.json()
+        self.assertEquals(response['body'].get('count'), 0)
+
+        line_data = dict(name='ruby rod supegreen', color='#8c8832')
+        response = self.client.post(self.url, line_data, format='json')
+        self.assertEquals(response.status_code, 201)
+
+        response = self.client.get(self.url)
+        response = response.json()
+        self.assertEquals(response['body'].get('count'), 1)
+
+    def test_update(self):
+        """test PATCH"""
+        # test initial order
+        line = factories.LineFactory()
+        response = self.client.get(self.url)
+        response_dict = response.json()
+        self.assertEquals(response_dict['body']['count'], 1)
+        self.assertEquals(response_dict['body']['results'][0]['color'], line.color)
+        # get uri to patch
+        detail_url = reverse('linemodel-detail', kwargs={'pk': line.id})
+        response = self.client.patch(detail_url, data={'color': '#8c8832'}, format='json')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.json()['color'], '#8c8832')
+
+    def test_delete(self):
+        factories.LineFactory.create_batch(10)
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        # get which station to delete
+        delete_obj = response.json()['body']['results'][0]['url']
+        response = self.client.delete(delete_obj)
+        self.assertEquals(response.status_code, 204)
+        # ensure it was deleted
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.json()['body']['count'], 9)

--- a/apps/lines/tests.py
+++ b/apps/lines/tests.py
@@ -2,7 +2,7 @@
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from users.factories import UserFactory
+from apps.users.factories import UserFactory
 from . import factories
 
 
@@ -17,7 +17,7 @@ class LineCRUDTest(APITestCase):
         response = response.json()
         self.assertEquals(response['body'].get('count'), 0)
 
-        line_data = dict(name='ruby rod supegreen', color='#8c8832')
+        line_data = {'name': 'ruby rod supegreen', 'color': '#8c8832'}
         response = self.client.post(self.url, line_data, format='json')
         self.assertEquals(response.status_code, 201)
 
@@ -51,3 +51,60 @@ class LineCRUDTest(APITestCase):
         response = self.client.get(self.url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.json()['body']['count'], 9)
+
+
+class RouteCRUDTest(APITestCase):
+    url = reverse('routemodel-list')
+
+    def setUp(self):
+        self.client.force_login(UserFactory())
+
+    def test_list_create(self):
+        line = factories.LineFactory()
+        sta = factories.StationFactory()
+        line_url = reverse('linemodel-detail', kwargs={'pk': line.id})
+        sta_url = reverse('stationmodel-detail', kwargs={'pk': sta.id})
+
+        route_data = {
+            'line': line_url,
+            'stations': [sta_url, sta_url]
+        }
+        response = self.client.post(self.url, route_data, format='json')
+        self.assertEquals(response.status_code, 201)
+
+        response = self.client.get(self.url)
+        response = response.json()
+        self.assertEquals(response['body'].get('count'), 1)
+
+    def test_update(self):
+        """test PUT"""
+        # test initial order
+        route4 = factories.RouteFactory(stations__num=4)
+        new_line = factories.LineFactory()
+        response = self.client.get(self.url)
+        response_dict = response.json()
+        self.assertEquals(response_dict['body']['count'], 1)
+        self.assertTrue(response_dict['body']['results'][0]['line'].endswith(route4.line.id+'/'))
+        self.assertFalse(response_dict['body']['results'][0]['line'].endswith(new_line.id+'/'))
+        # get uri to patch
+        detail_url = reverse('routemodel-detail', kwargs={'pk': route4.id})
+        route4_data = {
+            'line': reverse('linemodel-detail', kwargs={'pk': new_line.id}),
+            'stations': response_dict['body']['results'][0]['stations'],
+        }
+        response = self.client.put(detail_url, route4_data, format='json')
+        self.assertEquals(response.status_code, 200)
+        self.assertTrue(response.json()['line'].endswith(new_line.id+'/'))
+
+    def test_delete(self):
+        factories.RouteFactory.create_batch(3)
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        # get which station to delete
+        delete_obj = response.json()['body']['results'][0]['url']
+        response = self.client.delete(delete_obj)
+        self.assertEquals(response.status_code, 204)
+        # ensure it was deleted
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.json()['body']['count'], 2)

--- a/apps/lines/urls.py
+++ b/apps/lines/urls.py
@@ -1,0 +1,9 @@
+# coding: utf8
+from rest_framework.routers import SimpleRouter
+
+from . import views
+
+v1_router = SimpleRouter()
+v1_router.register('line', views.LineViewSet)
+v1_router.register('route', views.RouteViewSet)
+urlpatterns_v1_lines = v1_router.urls

--- a/apps/lines/views.py
+++ b/apps/lines/views.py
@@ -1,3 +1,16 @@
-from django.shortcuts import render
+# coding: utf8
 
-# Create your views here.
+from rest_framework.viewsets import ModelViewSet
+
+from . import models
+from . import serializers
+
+
+class LineViewSet(ModelViewSet):
+    queryset = models.LineModel.objects.all()
+    serializer_class = serializers.LineSerializer
+
+
+class RouteViewSet(ModelViewSet):
+    queryset = models.StationModel.objects.all()
+    serializer_class = serializers.RouteSerializer

--- a/apps/lines/views.py
+++ b/apps/lines/views.py
@@ -12,5 +12,5 @@ class LineViewSet(ModelViewSet):
 
 
 class RouteViewSet(ModelViewSet):
-    queryset = models.StationModel.objects.all()
+    queryset = models.RouteModel.objects.all()
     serializer_class = serializers.RouteSerializer

--- a/apps/stations/admin.py
+++ b/apps/stations/admin.py
@@ -1,5 +1,11 @@
 from django.contrib import admin
 
-from .models import LocationModel
+from . import models
 
-admin.site.register(LocationModel)
+
+class StationsAppAdmin(admin.ModelAdmin):
+    list_display = ('id', '__str__')
+
+
+admin.site.register(models.LocationModel, StationsAppAdmin)
+admin.site.register(models.StationModel, StationsAppAdmin)

--- a/apps/stations/admin.py
+++ b/apps/stations/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import LocationModel
+
+admin.site.register(LocationModel)

--- a/apps/stations/factories.py
+++ b/apps/stations/factories.py
@@ -1,14 +1,22 @@
 # coding: utf8
 import factory
 
-from .models import LocationModel
+from . import models
 
 
 class LocationFactory(factory.django.DjangoModelFactory):
 
     class Meta:
-        model = LocationModel
+        model = models.LocationModel
 
     name = factory.Faker('slug')
     latitude = factory.Faker('latitude')
     longitude = factory.Faker('longitude')
+
+class StationFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = models.StationModel
+
+    location = factory.SubFactory(LocationFactory)
+    order = 1

--- a/apps/stations/models/locations.py
+++ b/apps/stations/models/locations.py
@@ -15,6 +15,9 @@ class LocationModel(models.Model):
             geometry -- Similar to coordinate but using with postgis
     """
 
+    class Meta:
+        ordering = ('id',)
+
     id = models.CharField(default=create_id('loc_'), primary_key=True,
                           max_length=30, unique=True)
     name = models.CharField(max_length=100)

--- a/apps/stations/models/stations.py
+++ b/apps/stations/models/stations.py
@@ -1,15 +1,19 @@
 # coding: utf8
 from django.db import models
 
-from .locations import LocationModel
-
 from apps.utils import create_id
+from .locations import LocationModel
 
 
 class StationModel(models.Model):
+    class Meta:
+        ordering = ('id',)
 
     id = models.CharField(default=create_id('sta_'), primary_key=True,
                           max_length=30, unique=True)
     location = models.ForeignKey(LocationModel, on_delete=models.DO_NOTHING)
     order = models.IntegerField(default=0)
     is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return f'{self.order} @ {self.location} '

--- a/apps/stations/tests.py
+++ b/apps/stations/tests.py
@@ -85,7 +85,7 @@ class StationCRUDTest(APITestCase):
         self.assertEquals(response['body'].get('count'), 1)
 
     def test_update(self):
-        """Change the order of a factory Station"""
+        """Updates the order field of a factory made Station"""
         # test initial order
         sta = StationFactory()
         response = self.client.get(self.url)

--- a/apps/stations/tests.py
+++ b/apps/stations/tests.py
@@ -36,3 +36,15 @@ class LocationCreateTest(APITestCase):
 
         response = self.client.post(self.url, data, format='json')
         self.assertEquals(response.status_code, 201)
+
+    def test_non_empty_create(self):
+        LocationFactory.create_batch(4)
+
+        data = {
+            "name": "Urbvan",
+            "latitude": 19.388401,
+            "longitude": -99.227358
+        }
+
+        response = self.client.post(self.url, data, format='json')
+        self.assertEquals(response.status_code, 201)

--- a/apps/stations/tests.py
+++ b/apps/stations/tests.py
@@ -1,17 +1,16 @@
 # coding: utf8
-from django.urls import reverse
-
+from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from apps.users.factories import (UserFactory, TokenFactory)
-from apps.stations.factories import LocationFactory
+from apps.users.factories import UserFactory, TokenFactory
+from .factories import LocationFactory, StationFactory
 
 
-class LocationCreateTest(APITestCase):
-
-    url = reverse("locations:v1_list_create_location")
+class LocationViewSetTest(APITestCase):
+    url = reverse("locationmodel-list")
 
     def setUp(self):
+        # TODO factor out
         self.user = UserFactory()
         self.user_token = TokenFactory(user=self.user)
 
@@ -48,3 +47,66 @@ class LocationCreateTest(APITestCase):
 
         response = self.client.post(self.url, data, format='json')
         self.assertEquals(response.status_code, 201)
+
+    def test_detail(self):
+        loc = LocationFactory()
+        url = reverse('locationmodel-detail', kwargs={'pk': loc.id})
+        response = self.client.get(url).json()
+        self.assertEquals(loc.name, response['name'])
+
+
+class StationCRUDTest(APITestCase):
+    url = reverse('stationmodel-list')
+
+    def setUp(self):
+        # TODO factor out
+        self.user = UserFactory()
+        self.user_token = TokenFactory(user=self.user)
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Urbvan {}".format(self.user_token.key)
+        )
+
+    def test_list_create(self):
+        response = self.client.get(self.url)
+        response = response.json()
+        self.assertEquals(response['body'].get('count'), 0)
+
+        loc = LocationFactory()
+        data = {
+            "location": reverse('locationmodel-detail', kwargs={'pk': loc.id}),
+            "order": 1
+        }
+        response = self.client.post(self.url, data, format='json')
+        self.assertEquals(response.status_code, 201)
+
+        response = self.client.get(self.url)
+        response = response.json()
+        self.assertEquals(response['body'].get('count'), 1)
+
+    def test_update(self):
+        """Change the order of a factory Station"""
+        # test initial order
+        sta = StationFactory()
+        response = self.client.get(self.url)
+        response_dict = response.json()
+        self.assertEquals(response_dict['body']['count'], 1)
+        self.assertEquals(response_dict['body']['results'][0]['order'], sta.order)
+        # get Station to patch
+        detail_url = reverse('stationmodel-detail', kwargs={'pk': sta.id})
+        response = self.client.patch(detail_url, data={'order': 101}, format='json')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.json()['order'], 101)
+
+    def test_delete(self):
+        StationFactory.create_batch(10)
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        # get which station to delete
+        delete_sta = response.json()['body']['results'][0]['url']
+        response = self.client.delete(delete_sta)
+        self.assertEquals(response.status_code, 204)
+        # ensure it was deleted
+        response = self.client.get(self.url)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.json()['body']['count'], 9)

--- a/apps/stations/urls.py
+++ b/apps/stations/urls.py
@@ -1,12 +1,9 @@
 # coding: utf8
-from django.urls import path
+from rest_framework.routers import SimpleRouter
 
 from .v1 import views as views_v1
 
-urlpatterns_v1_locations = ([
-
-    path('',
-         views_v1.LocationView.as_view(),
-         name='v1_list_create_location'),
-
-], 'locations')
+v1_router = SimpleRouter()
+v1_router.register('location', views_v1.LocationViewSet)
+v1_router.register('station', views_v1.StationViewSet)
+urlpatterns_v1_locations = v1_router.urls

--- a/apps/stations/v1/serializers.py
+++ b/apps/stations/v1/serializers.py
@@ -1,11 +1,17 @@
 # coding: utf8
 from rest_framework import serializers
 
-from apps.stations.models import LocationModel
+from .. import models
 
 
-class LocationSerializer(serializers.ModelSerializer):
+class LocationSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
-        model = LocationModel
-        exclude = ('id', )
+        model = models.LocationModel
+        exclude = []
+
+
+class StationSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = models.StationModel
+        exclude = []

--- a/apps/stations/v1/views.py
+++ b/apps/stations/v1/views.py
@@ -1,14 +1,15 @@
 # coding: utf8
-from urbvan_framework.views import ListCreateView
+from rest_framework.viewsets import ModelViewSet
 
-from .schemas import LocationSchema
-from .serializers import LocationSerializer
-
-from ..models import LocationModel
+from . import serializers
+from .. import models
 
 
-class LocationView(ListCreateView):
+class LocationViewSet(ModelViewSet):
+    queryset = models.LocationModel.objects.all()
+    serializer_class = serializers.LocationSerializer
 
-    queryset = LocationModel.objects.all()
-    schema_class = LocationSchema
-    serializer_class = LocationSerializer
+
+class StationViewSet(ModelViewSet):
+    queryset = models.StationModel.objects.all()
+    serializer_class = serializers.StationSerializer

--- a/apps/users/factories.py
+++ b/apps/users/factories.py
@@ -18,6 +18,13 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_active = True
 
 
+class StaffUserFactory(UserFactory):
+    class Meta:
+        model = User
+
+    is_staff = True
+
+
 class TokenFactory(factory.django.DjangoModelFactory):
 
     class Meta:

--- a/apps/users/permissions.py
+++ b/apps/users/permissions.py
@@ -1,0 +1,18 @@
+# coding: utf8
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class CustomPermission(BasePermission):
+    """Custom DRF permissions class for urbvan test
+
+    Implements 3 leves of access:
+        - Anonymous: no access
+        - Authenticated: read only
+        - Staff: full access
+    """
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return request.user and request.user.is_authenticated
+        else:
+            return request.user and request.user.is_authenticated and request.user.is_staff

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,0 +1,59 @@
+# coding: utf8
+from unittest.mock import MagicMock
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.viewsets import ModelViewSet
+
+from apps.users.factories import UserFactory, StaffUserFactory
+from apps.users.permissions import CustomPermission
+
+
+class CustomPermissionsTest(SimpleTestCase):
+    def setUp(self):
+        self.anon_user = AnonymousUser()
+        self.user = UserFactory.build()
+        self.staff_user = StaffUserFactory.build()
+        self.view = ModelViewSet.as_view({
+            'get': 'list',
+            'post': 'create',
+        }, queryset=get_user_model().objects.none(), serializer_class=MagicMock(),
+            permission_classes=[CustomPermission])
+
+    def test_anonymous_read(self):
+        request = APIRequestFactory().get('/')
+        force_authenticate(request, user=self.anon_user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 403)
+
+    def test_anonymous_write(self):
+        request = APIRequestFactory().post('/', {})
+        force_authenticate(request, user=self.anon_user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 403)
+
+    def test_authenticated_read(self):
+        request = APIRequestFactory().get('/')
+        force_authenticate(request, user=self.user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 200)
+
+    def test_authenticated_write(self):
+        request = APIRequestFactory().post('/', {})
+        force_authenticate(request, user=self.user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 403)
+
+    def test_staff_read(self):
+        request = APIRequestFactory().get('/')
+        force_authenticate(request, user=self.staff_user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 200)
+
+    def test_staff_write(self):
+        request = APIRequestFactory().post('/', {})
+        force_authenticate(request, user=self.staff_user)
+        response = self.view(request)
+        self.assertEquals(response.status_code, 201)

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -2,18 +2,13 @@
 from datetime import datetime
 from uuid import uuid4
 
+from django.utils import timezone
 
-def create_id(identifier):
-    id_base = "{}{}{}{}{}{}{}{}"
-    now = datetime.utcnow()
-    id_base = id_base.format(
-        identifier,
-        now.year,
-        now.month,
-        now.day,
-        now.hour,
-        now.minute,
-        now.second,
-        str(uuid4())[:8]
-    )
-    return id_base
+
+def create_id(identifier: str) -> callable:
+    """Returns factory function which returns a unique identifier based on `identfier`, the date, and a uuid"""
+    def _create_id():
+        now = timezone.now()
+        uuid_ = str(uuid4())[:8]
+        return f'{identifier}{now.year}{now.month}{now.day}{now.hour}{now.minute}{now.second}{uuid_}'
+    return _create_id

--- a/urbvan/requirements/base.txt
+++ b/urbvan/requirements/base.txt
@@ -1,5 +1,4 @@
-Django==2.0.4
-django-rest-framework==0.1.0
+Django==2.1.1
 djangorestframework==3.8.2
 marshmallow==2.15.0
 factory-boy==2.10.0

--- a/urbvan/settings/base.py
+++ b/urbvan/settings/base.py
@@ -138,7 +138,7 @@ REST_FRAMEWORK = {
         'urbvan_framework.authentication.CustomTokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
+        'apps.users.permissions.CustomPermission',
     ),
     'DEFAULT_PAGINATION_CLASS': 'urbvan_framework.schemas.PaginationResponse',
 }

--- a/urbvan/settings/base.py
+++ b/urbvan/settings/base.py
@@ -135,6 +135,10 @@ STATIC_URL = '/static/'
 # Django rest framework configuration
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
-    )
+        'urbvan_framework.authentication.CustomTokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'urbvan_framework.schemas.PaginationResponse',
 }

--- a/urbvan/settings/local.py
+++ b/urbvan/settings/local.py
@@ -1,2 +1,6 @@
 # coding: utf8
 from .base import *
+
+# en la practica este archivo no se deberia agregar a git
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = \
+    ('rest_framework.authentication.SessionAuthentication',) + REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']

--- a/urbvan/urls.py
+++ b/urbvan/urls.py
@@ -4,11 +4,13 @@ from django.urls import (include, path)
 
 from rest_framework.authtoken import views
 
+from apps.lines.urls import urlpatterns_v1_lines
 from apps.stations.urls import urlpatterns_v1_locations
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api-token-auth/', views.obtain_auth_token),
 
-    path('v1/locations/', include(urlpatterns_v1_locations))
+    path('v1/', include(urlpatterns_v1_locations)),
+    path('v1/', include(urlpatterns_v1_lines)),
 ]


### PR DESCRIPTION
Agregue un CRUD para los modelos sumamente básico con la idea de terminar rápido. Por esto lo cambie a viewsets y modifique los urls para que usen el SimpleRouter.

También cambie los nombres de todas las rutas configuradas para facilitar la implementación de los HyperlinkedSerializers. Me hubiera gustado (hubiera sido mejor) dedicarle otro tratito para poder usar los HyperlinkeRelatedFields con los nombres de las rutas bien versionados y con sus namespaces bien puestos.

No quise modificar los modelos ni pude agregar validaciones o reglas de negocio debido a que francamente no tuve demasiado tiempo para pensar en ello. Además me surgieron varias dudas del tipo de dudas que necesito mas información para poder tratare de contestar. 

- ¿por que el campo `RouteModel.direction` es booleano? me parece difícil decidir si `True` es de ida o de venida...

- ¿por que existe `StationModel.order`? A mi entender el orden de una `Station` es en relacion a una `Line`. Como esta escrito el modelo, una `Station` tendría el mismo orden sin importar a cuales lineas se agregue.

No documente las cosas que considero practicas comunes y documentadas de django o django rest.